### PR TITLE
Parquet-Writer changes

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -79,17 +79,19 @@ public class ParquetProperties {
   private final WriterVersion writerVersion;
   private final boolean enableDictionary;
   private final ByteBufferAllocator allocator;
+  private final int pageSize;
 
   public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict) {
-    this(dictPageSize, writerVersion, enableDict, new HeapByteBufferAllocator());
+    this(dictPageSize, writerVersion, enableDict, new HeapByteBufferAllocator(), 1024*1024);
   }
 
-  public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict, ByteBufferAllocator allocator) {
+  public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict, ByteBufferAllocator allocator, int pageSize) {
     this.dictionaryPageSizeThreshold = dictPageSize;
     this.writerVersion = writerVersion;
     this.enableDictionary = enableDict;
     Preconditions.checkNotNull(allocator, "ByteBufferAllocator");
     this.allocator = allocator;
+    this.pageSize = pageSize;
   }
 
   public ValuesWriter getColumnDescriptorValuesWriter(int maxLevel, int initialSizePerCol, int pageSize) {
@@ -121,7 +123,7 @@ public class ParquetProperties {
     }
   }
 
-  private DictionaryValuesWriter dictionaryWriter(ColumnDescriptor path, int initialSizePerCol) {
+  public DictionaryValuesWriter dictionaryWriter(ColumnDescriptor path, int initialSizePerCol) {
     Encoding encodingForDataPage;
     Encoding encodingForDictionaryPage;
     switch(writerVersion) {
@@ -158,7 +160,7 @@ public class ParquetProperties {
     }
   }
 
-  private ValuesWriter writerToFallbackTo(ColumnDescriptor path, int initialSizePerCol, int pageSize) {
+  public ValuesWriter writerToFallbackTo(ColumnDescriptor path, int initialSizePerCol, int pageSize) {
     switch(writerVersion) {
     case PARQUET_1_0:
       return plainWriter(path, initialSizePerCol, pageSize);
@@ -230,6 +232,10 @@ public class ParquetProperties {
     return enableDictionary;
   }
 
+  public int getPageSize() {
+    return pageSize;
+  }
+
   public ByteBufferAllocator getAllocator() {
     return allocator;
   }
@@ -251,7 +257,7 @@ public class ParquetProperties {
           schema,
           pageStore,
           pageSize,
-          new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary, allocator));
+          new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary, allocator, pageSize));
     default:
       throw new IllegalArgumentException("unknown version " + writerVersion);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/SortedDictionary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/SortedDictionary.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
+import org.apache.parquet.io.ParquetDecodingException;
+
+/**
+ * Sorted dictionary
+ */
+public class SortedDictionary {
+
+  private final Dictionary dictionary;
+  private final Map<Integer, Integer> sortedDictionaryId;
+  private final DictionaryPage sortedDictionaryPage;
+
+  public SortedDictionary(DictionaryPage dictionaryPage, final ColumnDescriptor columnDescriptor, ParquetProperties parquetProperties) throws IOException {
+    this.sortedDictionaryId = new HashMap<Integer, Integer>();
+    this.dictionary = dictionaryPage.getEncoding().initDictionary(columnDescriptor, dictionaryPage);
+
+    final Integer []indices = new Integer[dictionary.getMaxId() + 1];
+    for (int i = 0; i < indices.length; ++i) {
+      indices[i] = i;
+    }
+    Arrays.sort(indices, new Comparator<Integer>() {
+      @Override
+      public int compare(Integer o1, Integer o2) {
+        switch (columnDescriptor.getType()) {
+          case BOOLEAN: // boolean shouldn't have dictionary encoding
+            return Boolean.compare(dictionary.decodeToBoolean(o1), dictionary.decodeToBoolean(o2));
+          case BINARY:
+          case FIXED_LEN_BYTE_ARRAY:
+          case INT96:
+            return dictionary.decodeToBinary(o1).compareTo(dictionary.decodeToBinary(o2));
+          case INT32:
+            return Integer.compare(dictionary.decodeToInt(o1), dictionary.decodeToInt(o2));
+          case INT64:
+            return Long.compare(dictionary.decodeToLong(o1), dictionary.decodeToLong(o2));
+          case DOUBLE:
+            return Double.compare(dictionary.decodeToDouble(o1), dictionary.decodeToDouble(o2));
+          case FLOAT:
+            return Float.compare(dictionary.decodeToFloat(o1), dictionary.decodeToFloat(o2));
+          default:
+            throw new ParquetDecodingException("Dictionary encoding not supported for type: " + columnDescriptor.getType());
+        }
+      }
+    });
+
+    for (int i = 0; i < indices.length; ++i) {
+      // map old dictionary id to new one
+      sortedDictionaryId.put(indices[i], i);
+    }
+
+    // Create sorted dictionary page.
+    final DictionaryValuesWriter dictionaryValuesWriter = parquetProperties.dictionaryWriter(columnDescriptor, dictionaryPage.getDictionarySize());
+    try {
+      switch (columnDescriptor.getType()) {
+        case BOOLEAN: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeBoolean(dictionary.decodeToBoolean(indices[i]));
+          }
+          break;
+        }
+
+        case BINARY:
+        case FIXED_LEN_BYTE_ARRAY:
+        case INT96: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeBytes(dictionary.decodeToBinary(indices[i]));
+          }
+          break;
+        }
+
+        case INT32: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeInteger(dictionary.decodeToInt(indices[i]));
+          }
+          break;
+        }
+
+        case INT64: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeLong(dictionary.decodeToLong(indices[i]));
+          }
+          break;
+        }
+
+        case DOUBLE: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeDouble(dictionary.decodeToDouble(indices[i]));
+          }
+          break;
+        }
+
+        case FLOAT: {
+          for (int i = 0; i < indices.length; ++i) {
+            dictionaryValuesWriter.writeFloat(dictionary.decodeToFloat(indices[i]));
+          }
+          break;
+        }
+
+        default:
+          throw new ParquetDecodingException("Dictionary encoding not supported for type: " + columnDescriptor.getType());
+      }
+      // consume dictionary before calling toDictPageAndClose
+      dictionaryValuesWriter.consumeDictionary();
+      this.sortedDictionaryPage = dictionaryValuesWriter.toDictPageAndClose();
+    } finally {
+      dictionaryValuesWriter.close();
+    }
+  }
+
+  public Dictionary getDictionary() {
+    return dictionary;
+  }
+
+  public int getNewId(int id) {
+    return sortedDictionaryId.get(id);
+  }
+
+  public DictionaryPage getSortedDictionaryPage() {
+    return sortedDictionaryPage;
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterV1.java
@@ -76,7 +76,7 @@ final class ColumnWriterV1 implements ColumnWriter {
     this.valueCountForNextSizeCheck = INITIAL_COUNT_FOR_SIZE_CHECK;
     resetStatistics();
 
-    ParquetProperties parquetProps = new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary, allocator);
+    ParquetProperties parquetProps = new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary, allocator, pageSizeThreshold);
 
     this.repetitionLevelColumn = parquetProps.getColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);
     this.definitionLevelColumn = parquetProps.getColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
@@ -155,34 +155,49 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
     return encodedValues.size() * 4 + dictionaryByteSize;
   }
 
-  @Override
-  public BytesInput getBytes() {
-    int maxDicId = getDictionarySize() - 1;
+  /**
+   * Get bytes for given encoded values
+   * Note that this code is simply encoding values so should not have any side effects except keeping track of encoders
+   * @param encodedValues dictionary ids for encoded values
+   * @return dictionary encoded data
+   */
+  public BytesInput getBytes(IntList encodedValues) {
+    final int maxDicId = getDictionarySize() - 1;
     if (DEBUG) LOG.debug("max dic id " + maxDicId);
-    int bitWidth = BytesUtils.getWidthFromMaxInt(maxDicId);
-    int initialSlabSize =
-        CapacityByteArrayOutputStream.initialSlabSizeHeuristic(MIN_INITIAL_SLAB_SIZE, maxDictionaryByteSize, 10);
+    final int bitWidth = BytesUtils.getWidthFromMaxInt(maxDicId);
+    final int initialSlabSize =
+      CapacityByteArrayOutputStream.initialSlabSizeHeuristic(MIN_INITIAL_SLAB_SIZE, maxDictionaryByteSize, 10);
 
-    RunLengthBitPackingHybridEncoder encoder =
-        new RunLengthBitPackingHybridEncoder(bitWidth, initialSlabSize, maxDictionaryByteSize, this.allocator);
+    final RunLengthBitPackingHybridEncoder encoder =
+      new RunLengthBitPackingHybridEncoder(bitWidth, initialSlabSize, maxDictionaryByteSize, this.allocator);
     encoders.add(encoder);
-    IntIterator iterator = encodedValues.iterator();
+    final IntIterator iterator = encodedValues.iterator();
     try {
       while (iterator.hasNext()) {
         encoder.writeInt(iterator.next());
       }
       // encodes the bit width
-      byte[] bytesHeader = new byte[] { (byte) bitWidth };
-      BytesInput rleEncodedBytes = encoder.toBytes();
+      final byte[] bytesHeader = new byte[] { (byte) bitWidth };
+      final BytesInput rleEncodedBytes = encoder.toBytes();
       if (DEBUG) LOG.debug("rle encoded bytes " + rleEncodedBytes.size());
-      BytesInput bytes = concat(BytesInput.from(bytesHeader), rleEncodedBytes);
-      // remember size of dictionary when we last wrote a page
-      lastUsedDictionarySize = getDictionarySize();
-      lastUsedDictionaryByteSize = dictionaryByteSize;
+      final BytesInput bytes = concat(BytesInput.from(bytesHeader), rleEncodedBytes);
       return bytes;
     } catch (IOException e) {
       throw new ParquetEncodingException("could not encode the values", e);
     }
+  }
+
+  public void consumeDictionary() {
+    // remember size of dictionary when we last wrote a page
+    lastUsedDictionarySize = getDictionarySize();
+    lastUsedDictionaryByteSize = dictionaryByteSize;
+  }
+
+  @Override
+  public BytesInput getBytes() {
+    final BytesInput data = getBytes(encodedValues);
+    consumeDictionary();
+    return data;
   }
 
   @Override

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
@@ -191,7 +191,7 @@ public class TestCorruptDeltaByteArrays {
     MemPageStore pages = new MemPageStore(0);
     PageWriter memWriter = pages.getPageWriter(column);
 
-    ParquetProperties parquetProps = new ParquetProperties(0, ParquetProperties.WriterVersion.PARQUET_1_0, false, new HeapByteBufferAllocator());
+    ParquetProperties parquetProps = new ParquetProperties(0, ParquetProperties.WriterVersion.PARQUET_1_0, false);
 
     // get generic repetition and definition level bytes to use for pages
     ValuesWriter rdValues = parquetProps.getColumnDescriptorValuesWriter(0, 10, 100);

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -18,26 +18,27 @@
  */
 package org.apache.parquet.column.values.dictionary;
 
-import static org.junit.Assert.assertEquals;
 import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 
-import org.junit.Assert;
-import org.junit.Test;
-
-import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.SortedDictionary;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
@@ -52,6 +53,8 @@ import org.apache.parquet.column.values.plain.PlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestDictionary {
 
@@ -531,5 +534,167 @@ public class TestDictionary {
     assertEquals(encoding, cw.getEncoding());
     cw.reset();
     return bytes;
+  }
+
+
+  @Test
+  public void testSortedDictionaryBinary() throws Exception {
+    final ColumnDescriptor column = new ColumnDescriptor(new String[] {"foo"}, BINARY, 0, 0);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+
+    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(4096, 10000);
+    cw.writeBytes(Binary.fromString("b"));
+    cw.writeBytes(Binary.fromString("a"));
+    cw.writeBytes(Binary.fromString("z"));
+    cw.writeBytes(Binary.fromString("b"));
+    cw.writeBytes(Binary.fromString("c"));
+    cw.writeBytes(Binary.fromString("d"));
+    cw.writeBytes(Binary.fromString("a"));
+    cw.writeBytes(Binary.fromString("z"));
+    cw.writeBytes(Binary.fromString("b"));
+
+    // use dictionary before getting dictionary page
+    cw.getBytes();
+    cw.getEncoding();
+    DictionaryPage dictionaryPage = cw.toDictPageAndClose();
+    SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, column, parquetProperties);
+
+    final Dictionary dictionary = PLAIN.initDictionary(column, sortedDictionary.getSortedDictionaryPage());
+    assertEquals(4, dictionary.getMaxId());
+    assertEquals("a", dictionary.decodeToBinary(0).toStringUsingUTF8());
+    assertEquals("b", dictionary.decodeToBinary(1).toStringUsingUTF8());
+    assertEquals("c", dictionary.decodeToBinary(2).toStringUsingUTF8());
+    assertEquals("d", dictionary.decodeToBinary(3).toStringUsingUTF8());
+    assertEquals("z", dictionary.decodeToBinary(4).toStringUsingUTF8());
+  }
+
+  @Test
+  public void testSortedDictionaryLong() throws IOException {
+    final ColumnDescriptor column = new ColumnDescriptor(new String[] {"foo"}, INT64, 0, 0);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+
+    ValuesWriter cw = newPlainLongDictionaryValuesWriter(4096, 10000);
+    cw.writeLong(10);
+    cw.writeLong(0);
+    cw.writeLong(-1);
+    cw.writeLong(2);
+    cw.writeLong(1);
+    cw.writeLong(2);
+    cw.writeLong(9);
+    cw.writeLong(10);
+    cw.writeLong(-1);
+
+    // use dictionary before getting dictionary page
+    cw.getBytes();
+    cw.getEncoding();
+    DictionaryPage dictionaryPage = cw.toDictPageAndClose();
+    SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, column, parquetProperties);
+
+    final Dictionary dictionary = PLAIN.initDictionary(column, sortedDictionary.getSortedDictionaryPage());
+    assertEquals(5, dictionary.getMaxId());
+    assertEquals(-1, dictionary.decodeToLong(0));
+    assertEquals(0, dictionary.decodeToLong(1));
+    assertEquals(1, dictionary.decodeToLong(2));
+    assertEquals(2, dictionary.decodeToLong(3));
+    assertEquals(9, dictionary.decodeToLong(4));
+    assertEquals(10, dictionary.decodeToLong(5));
+  }
+
+  @Test
+  public void testSortedDictionaryInteger() throws IOException {
+    final ColumnDescriptor column = new ColumnDescriptor(new String[] {"foo"}, INT32, 0, 0);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+
+    ValuesWriter cw = newPlainIntegerDictionaryValuesWriter(4096, 10000);
+    cw.writeInteger(10);
+    cw.writeInteger(0);
+    cw.writeInteger(-1);
+    cw.writeInteger(2);
+    cw.writeInteger(1);
+    cw.writeInteger(2);
+    cw.writeInteger(9);
+    cw.writeInteger(-2);
+    cw.writeInteger(20);
+    cw.writeInteger(10);
+    cw.writeInteger(-1);
+
+    // use dictionary before getting dictionary page
+    cw.getBytes();
+    cw.getEncoding();
+    DictionaryPage dictionaryPage = cw.toDictPageAndClose();
+    SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, column, parquetProperties);
+
+    final Dictionary dictionary = PLAIN.initDictionary(column, sortedDictionary.getSortedDictionaryPage());
+    assertEquals(7, dictionary.getMaxId());
+    assertEquals(-2, dictionary.decodeToInt(0));
+    assertEquals(-1, dictionary.decodeToInt(1));
+    assertEquals(0, dictionary.decodeToInt(2));
+    assertEquals(1, dictionary.decodeToInt(3));
+    assertEquals(2, dictionary.decodeToInt(4));
+    assertEquals(9, dictionary.decodeToInt(5));
+    assertEquals(10, dictionary.decodeToInt(6));
+    assertEquals(20, dictionary.decodeToInt(7));
+  }
+
+  @Test
+  public void testSortedDictionaryDouble() throws IOException {
+    final ColumnDescriptor column = new ColumnDescriptor(new String[] {"foo"}, DOUBLE, 0, 0);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+
+    ValuesWriter cw = newPlainDoubleDictionaryValuesWriter(4096, 10000);
+    cw.writeDouble(10.12);
+    cw.writeDouble(12.12);
+    cw.writeDouble(0.12);
+    cw.writeDouble(-1);
+    cw.writeDouble(12.12);
+    cw.writeDouble(11.11);
+    cw.writeDouble(1);
+    cw.writeDouble(-1);
+
+    // use dictionary before getting dictionary page
+    cw.getBytes();
+    cw.getEncoding();
+    DictionaryPage dictionaryPage = cw.toDictPageAndClose();
+    SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, column, parquetProperties);
+
+    final Dictionary dictionary = PLAIN.initDictionary(column, sortedDictionary.getSortedDictionaryPage());
+    assertEquals(5, dictionary.getMaxId());
+    assertEquals(-1, dictionary.decodeToDouble(0), 0);
+    assertEquals(0.12, dictionary.decodeToDouble(1), 0);
+    assertEquals(1, dictionary.decodeToDouble(2), 0);
+    assertEquals(10.12, dictionary.decodeToDouble(3), 0);
+    assertEquals(11.11, dictionary.decodeToDouble(4), 0);
+    assertEquals(12.12, dictionary.decodeToDouble(5), 0);
+  }
+
+  @Test
+  public void testSortedDictionaryFloat() throws IOException {
+    final ColumnDescriptor column = new ColumnDescriptor(new String[] {"foo"}, FLOAT, 0, 0);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+
+    ValuesWriter cw = newPlainFloatDictionaryValuesWriter(4096, 10000);
+    cw.writeFloat(10.12f);
+    cw.writeFloat(12.12f);
+    cw.writeFloat(0.12f);
+    cw.writeFloat(-1f);
+    cw.writeFloat(12.12f);
+    cw.writeFloat(11.11f);
+    cw.writeFloat(1f);
+    cw.writeFloat(-1f);
+
+    // use dictionary before getting dictionary page
+    cw.getBytes();
+    cw.getEncoding();
+    DictionaryPage dictionaryPage = cw.toDictPageAndClose();
+    SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, column, parquetProperties);
+
+    final Dictionary dictionary = PLAIN.initDictionary(column, sortedDictionary.getSortedDictionaryPage());
+    assertEquals(5, dictionary.getMaxId());
+    assertEquals(-1f, dictionary.decodeToFloat(0), 0);
+    assertEquals(0.12f, dictionary.decodeToFloat(1), 0);
+    assertEquals(1f, dictionary.decodeToFloat(2), 0);
+    assertEquals(10.12f, dictionary.decodeToFloat(3), 0);
+    assertEquals(11.11f, dictionary.decodeToFloat(4), 0);
+    assertEquals(12.12f, dictionary.decodeToFloat(5), 0);
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
+import static java.lang.String.format;
 import static org.apache.parquet.Log.INFO;
 import static org.apache.parquet.column.statistics.Statistics.getStatsBasedOnType;
 
@@ -26,23 +27,35 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.parquet.Log;
+import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.ConcatenatingByteArrayCollector;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.SortedDictionary;
+import org.apache.parquet.column.ValuesType;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageWriteStore;
 import org.apache.parquet.column.page.PageWriter;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.IntList;
+import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.CodecFactory.BytesCompressor;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.ParquetEncodingException;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.bytes.ByteBufferAllocator;
 
 class ColumnChunkPageWriteStore implements PageWriteStore {
   private static final Log LOG = Log.getLog(ColumnChunkPageWriteStore.class);
@@ -61,30 +74,46 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
     private long uncompressedLength;
     private long compressedLength;
     private long totalValueCount;
+    private long bufferedSize;
     private int pageCount;
+    private final List<PageHeaderWithOffset> pageHeaderWithOffsets = new ArrayList<PageHeaderWithOffset>();
 
     private Set<Encoding> encodings = new HashSet<Encoding>();
+    private List<PageHolder> bufferedPages = new ArrayList<PageHolder>();
 
     private Statistics totalStatistics;
-    private final ByteBufferAllocator allocator;
+    private ParquetProperties parquetProperties;
 
     private ColumnChunkPageWriter(ColumnDescriptor path,
                                   BytesCompressor compressor,
-                                  ByteBufferAllocator allocator) {
+                                  ParquetProperties parquetProperties) {
       this.path = path;
       this.compressor = compressor;
-      this.allocator = allocator;
+      this.parquetProperties = parquetProperties;
       this.buf = new ConcatenatingByteArrayCollector();
       this.totalStatistics = getStatsBasedOnType(this.path.getType());
+
     }
 
     @Override
-    public void writePage(BytesInput bytes,
+    public void writePage(BytesInput data,
                           int valueCount,
                           Statistics statistics,
                           Encoding rlEncoding,
                           Encoding dlEncoding,
                           Encoding valuesEncoding) throws IOException {
+      this.totalValueCount += valueCount;
+      this.pageCount += 1;
+      this.totalStatistics.mergeStatistics(statistics);
+      this.bufferedSize += data.size();
+
+      bufferedPages.add(new PageV1Holder(pageCount, path,
+        data, valueCount, statistics, rlEncoding, dlEncoding, valuesEncoding));
+    }
+
+    private PageHeaderWithOffset preparePage(PageV1Holder pageV1Holder, long currentPos) throws IOException {
+      final BytesInput bytes = pageV1Holder.getData();
+
       long uncompressedSize = bytes.size();
       if (uncompressedSize > Integer.MAX_VALUE) {
         throw new ParquetEncodingException(
@@ -99,26 +128,25 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
                 + compressedSize);
       }
       tempOutputStream.reset();
-      parquetMetadataConverter.writeDataPageHeader(
+      final PageHeader pageHeader = parquetMetadataConverter.writeDataPageHeader(
           (int)uncompressedSize,
           (int)compressedSize,
-          valueCount,
-          statistics,
-          rlEncoding,
-          dlEncoding,
-          valuesEncoding,
+          pageV1Holder.getValueCount(),
+          pageV1Holder.getStatistics(),
+          pageV1Holder.getRlEncoding(),
+          pageV1Holder.getDlEncoding(),
+          pageV1Holder.getValuesEncoding(),
           tempOutputStream);
       this.uncompressedLength += uncompressedSize;
       this.compressedLength += compressedSize;
-      this.totalValueCount += valueCount;
-      this.pageCount += 1;
-      this.totalStatistics.mergeStatistics(statistics);
       // by concatenating before collecting instead of collecting twice,
       // we only allocate one buffer to copy into instead of multiple.
       buf.collect(BytesInput.concat(BytesInput.from(tempOutputStream), compressedBytes));
-      encodings.add(rlEncoding);
-      encodings.add(dlEncoding);
-      encodings.add(valuesEncoding);
+
+      encodings.add(pageV1Holder.getRlEncoding());
+      encodings.add(pageV1Holder.getDlEncoding());
+      encodings.add(pageV1Holder.getValuesEncoding());
+      return new PageHeaderWithOffset(pageHeader, currentPos + tempOutputStream.size());
     }
 
     @Override
@@ -127,6 +155,21 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
         BytesInput repetitionLevels, BytesInput definitionLevels,
         Encoding dataEncoding, BytesInput data,
         Statistics<?> statistics) throws IOException {
+      this.totalValueCount += valueCount;
+      this.pageCount += 1;
+      this.totalStatistics.mergeStatistics(statistics);
+      int totalSize = toIntWithCheck(
+        data.size() + repetitionLevels.size() + definitionLevels.size());
+      this.bufferedSize += totalSize;
+      bufferedPages.add(new PageV2Holder(pageCount, path,
+        rowCount, nullCount, valueCount, repetitionLevels, definitionLevels, dataEncoding, data, statistics));
+    }
+
+    private PageHeaderWithOffset preparePage(PageV2Holder pageV2Holder, long currentPos) throws IOException {
+      final BytesInput repetitionLevels = pageV2Holder.getRepetitionLevels();
+      final BytesInput definitionLevels = pageV2Holder.getDefinitionLevels();
+      final BytesInput data = pageV2Holder.getData();
+
       int rlByteLength = toIntWithCheck(repetitionLevels.size());
       int dlByteLength = toIntWithCheck(definitionLevels.size());
       int uncompressedSize = toIntWithCheck(
@@ -138,19 +181,18 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
           compressedData.size() + repetitionLevels.size() + definitionLevels.size()
       );
       tempOutputStream.reset();
-      parquetMetadataConverter.writeDataPageV2Header(
+      final PageHeader pageHeader = parquetMetadataConverter.writeDataPageV2Header(
           uncompressedSize, compressedSize,
-          valueCount, nullCount, rowCount,
-          statistics,
-          dataEncoding,
+          pageV2Holder.getValueCount(),
+          pageV2Holder.getNullCount(),
+          pageV2Holder.getRowCount(),
+          pageV2Holder.getStatistics(),
+          pageV2Holder.getValuesEncoding(),
           rlByteLength,
           dlByteLength,
           tempOutputStream);
       this.uncompressedLength += uncompressedSize;
       this.compressedLength += compressedSize;
-      this.totalValueCount += valueCount;
-      this.pageCount += 1;
-      this.totalStatistics.mergeStatistics(statistics);
 
       // by concatenating before collecting instead of collecting twice,
       // we only allocate one buffer to copy into instead of multiple.
@@ -161,7 +203,8 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
               definitionLevels,
               compressedData)
       );
-      encodings.add(dataEncoding);
+      encodings.add(pageV2Holder.getValuesEncoding());
+      return new PageHeaderWithOffset(pageHeader, currentPos + tempOutputStream.size());
     }
 
     private int toIntWithCheck(long size) {
@@ -178,26 +221,149 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
       return buf.size();
     }
 
-    public void writeToFileWriter(ParquetFileWriter writer) throws IOException {
+    private void writeBufferedPages(ParquetFileWriter writer, DictionaryPage dictionaryPage) throws IOException {
       writer.startColumn(path, totalValueCount, compressor.getCodecName());
       if (dictionaryPage != null) {
-        writer.writeDictionaryPage(dictionaryPage);
+        // compress dictionary page before writing
+        pageHeaderWithOffsets.add(writer.writeDictionaryPage(
+          new DictionaryPage(compressor.compress(dictionaryPage.getBytes()), dictionaryPage.getUncompressedSize(), dictionaryPage.getDictionarySize(), dictionaryPage.getEncoding())));
         encodings.add(dictionaryPage.getEncoding());
+      }
+
+      // start from current offset in output file, until now page with offsets have saved page sizes.
+      long pageOffset = writer.getPos();
+      for (PageHolder bufferedPage : bufferedPages) {
+        final PageHeaderWithOffset pageHeader;
+        if (bufferedPage instanceof PageV1Holder) {
+          pageHeader = preparePage((PageV1Holder)bufferedPage, pageOffset);
+        } else {
+          pageHeader = preparePage((PageV2Holder)bufferedPage, pageOffset);
+        }
+        pageHeaderWithOffsets.add(pageHeader);
+        // add compressed size of this page to page offset which should be staring offset of the next page
+        pageOffset = pageHeader.getOffset() + pageHeader.getPageHeader().getCompressed_page_size();
       }
       writer.writeDataPages(buf, uncompressedLength, compressedLength, totalStatistics, new ArrayList<Encoding>(encodings));
       writer.endColumn();
       if (INFO) {
         LOG.info(
-            String.format(
-                "written %,dB for %s: %,d values, %,dB raw, %,dB comp, %d pages, encodings: %s",
-                buf.size(), path, totalValueCount, uncompressedLength, compressedLength, pageCount, encodings)
-                + (dictionaryPage != null ? String.format(
-                ", dic { %,d entries, %,dB raw, %,dB comp}",
-                dictionaryPage.getDictionarySize(), dictionaryPage.getUncompressedSize(), dictionaryPage.getDictionarySize())
-                : ""));
+          String.format(
+            "written %,dB for %s: %,d values, %,dB raw, %,dB comp, %d pages, encodings: %s",
+            buf.size(), path, totalValueCount, uncompressedLength, compressedLength, pageCount, encodings)
+            + (dictionaryPage != null ? String.format(
+            ", dic { %,d entries, %,dB raw, %,dB comp}",
+            dictionaryPage.getDictionarySize(), dictionaryPage.getUncompressedSize(), dictionaryPage.getDictionarySize())
+            : ""));
       }
       encodings.clear();
       pageCount = 0;
+    }
+
+    private void checkDictionaryEncoding() throws IOException {
+      if (dictionaryPage != null) {
+        boolean allDictionaryEncodedPages = true;
+        for (PageHolder pageHolder : bufferedPages) {
+          if (!pageHolder.getValuesEncoding().usesDictionary()) {
+            allDictionaryEncodedPages = false;
+            break;
+          }
+        }
+        // Undo dictionary encoding
+        if (!allDictionaryEncodedPages) {
+          final Dictionary dictionary = dictionaryPage.getEncoding().initDictionary(path, dictionaryPage);
+          for (PageHolder pageHolder : bufferedPages) {
+            if (pageHolder.getValuesEncoding().usesDictionary()) {
+              final ValuesWriter valuesWriter = parquetProperties.writerToFallbackTo(path,
+                (int)pageHolder.getData().size(), parquetProperties.getPageSize());
+              final ValuesReader dictionaryBasedValuesReader =
+                pageHolder.getValuesEncoding().getDictionaryBasedValuesReader(path, ValuesType.VALUES, dictionary);
+              final int pageDataOffset = pageHolder.getDataOffset();
+              dictionaryBasedValuesReader.initFromPage(pageHolder.getValueCount(), pageHolder.getData().toByteBuffer(), pageDataOffset);
+              try {
+                // read value from dictionary reader and write to plain/fallback value writer
+                for (int i = 0; i < pageHolder.getNonNullValueCount(); ++i) {
+                  switch (path.getType()) {
+                    case BOOLEAN: // boolean shouldn't have dictionary encoding
+                      valuesWriter.writeBoolean(dictionaryBasedValuesReader.readBoolean());
+                      break;
+                    case BINARY:
+                    case FIXED_LEN_BYTE_ARRAY:
+                    case INT96:
+                      valuesWriter.writeBytes(dictionaryBasedValuesReader.readBytes());
+                      break;
+                    case INT32:
+                      valuesWriter.writeInteger(dictionaryBasedValuesReader.readInteger());
+                      break;
+                    case INT64:
+                      valuesWriter.writeLong(dictionaryBasedValuesReader.readLong());
+                      break;
+                    case DOUBLE:
+                      valuesWriter.writeDouble(dictionaryBasedValuesReader.readDouble());
+                      break;
+                    case FLOAT:
+                      valuesWriter.writeFloat(dictionaryBasedValuesReader.readFloat());
+                      break;
+                    default:
+                      throw new ParquetDecodingException("Dictionary encoding not supported for type: " + path.getType());
+                  }
+                }
+                // reset data and page encoding
+                if (pageHolder instanceof PageV1Holder) {
+                  final BytesInput rldlBytes = BytesInput.from(pageHolder.getData().toByteBuffer(), 0, pageDataOffset);
+                  pageHolder.setData(BytesInput.concat(rldlBytes, BytesInput.copy(valuesWriter.getBytes())));
+                } else {
+                  pageHolder.setData(BytesInput.copy(valuesWriter.getBytes()));
+                }
+                pageHolder.setValuesEncoding(valuesWriter.getEncoding());
+              } finally {
+                valuesWriter.close();
+              }
+            }
+          }
+          dictionaryPage = null;
+        }
+      }
+    }
+
+    public void writeToFileWriter(ParquetFileWriter writer) throws IOException {
+      checkDictionaryEncoding();
+
+      if (dictionaryPage == null) {
+        writeBufferedPages(writer, null);
+        return;
+      }
+
+      // Copy dictionary page and create a sorted dictionary
+      final SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, path, parquetProperties);
+
+      // For each buffered page, read dictionary ids and map them to new ids.
+      // Use dictionary writer to serialize newly encoded values to bytes
+      for (PageHolder pageHolder : bufferedPages) {
+        final BytesInput data = pageHolder.getData();
+        final int pageDataOffset = pageHolder.getDataOffset();
+        final Encoding valuesEncoding = pageHolder.getValuesEncoding();
+        final ValuesReader dictionaryBasedValuesReader =
+          valuesEncoding.getDictionaryBasedValuesReader(path, ValuesType.VALUES, sortedDictionary.getDictionary());
+        dictionaryBasedValuesReader.initFromPage(pageHolder.getValueCount(), data.toByteBuffer(), pageDataOffset);
+
+        final DictionaryValuesWriter valuesWriter = parquetProperties.dictionaryWriter(path, /*ignored */ (int)data.size());
+        final IntList encodedValues = new IntList();
+        try {
+          for (int i = 0; i < pageHolder.getNonNullValueCount(); ++i) {
+            final int oldDictionaryId = dictionaryBasedValuesReader.readValueDictionaryId();
+            encodedValues.add(sortedDictionary.getNewId(oldDictionaryId));
+          }
+          if (pageHolder instanceof PageV1Holder) {
+            final BytesInput rldlBytes = BytesInput.from(data.toByteBuffer(), 0, pageDataOffset);
+            pageHolder.setData(BytesInput.concat(rldlBytes, BytesInput.copy(valuesWriter.getBytes(encodedValues))));
+          } else {
+            pageHolder.setData(BytesInput.copy(valuesWriter.getBytes(encodedValues)));
+          }
+        } finally {
+          valuesWriter.close();
+        }
+      }
+      writeBufferedPages(writer, sortedDictionary.getSortedDictionaryPage());
     }
 
     @Override
@@ -212,30 +378,45 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
       }
       BytesInput dictionaryBytes = dictionaryPage.getBytes();
       int uncompressedSize = (int)dictionaryBytes.size();
-      BytesInput compressedBytes = compressor.compress(dictionaryBytes);
-      this.dictionaryPage = new DictionaryPage(BytesInput.copy(compressedBytes), uncompressedSize, dictionaryPage.getDictionarySize(), dictionaryPage.getEncoding());
+      this.dictionaryPage = new DictionaryPage(BytesInput.copy(dictionaryBytes), uncompressedSize, dictionaryPage.getDictionarySize(), dictionaryPage.getEncoding());
     }
 
     @Override
     public String memUsageString(String prefix) {
-      return buf.memUsageString(prefix + " ColumnChunkPageWriter");
+      return format("Memory used before sorting dictionary: %d, after dictionary sorting %s",
+        bufferedSize, buf.memUsageString(prefix + " ColumnChunkPageWriter"));
     }
 
+    public List<PageHeaderWithOffset> getPageHeaderWithOffsets() {
+      return pageHeaderWithOffsets;
+    }
   }
 
   private final Map<ColumnDescriptor, ColumnChunkPageWriter> writers = new HashMap<ColumnDescriptor, ColumnChunkPageWriter>();
   private final MessageType schema;
 
   public ColumnChunkPageWriteStore(BytesCompressor compressor, MessageType schema, ByteBufferAllocator allocator) {
+    this(compressor, schema, new ParquetProperties(ParquetWriter.DEFAULT_PAGE_SIZE, null, false, allocator, ParquetWriter.DEFAULT_PAGE_SIZE));
+  }
+
+  public ColumnChunkPageWriteStore(BytesCompressor compressor, MessageType schema, ParquetProperties parquetProperties) {
     this.schema = schema;
     for (ColumnDescriptor path : schema.getColumns()) {
-      writers.put(path,  new ColumnChunkPageWriter(path, compressor, allocator));
+      writers.put(path,  new ColumnChunkPageWriter(path, compressor, parquetProperties));
     }
   }
 
   @Override
   public PageWriter getPageWriter(ColumnDescriptor path) {
     return writers.get(path);
+  }
+
+  public Map<ColumnPath, List<PageHeaderWithOffset>> getPageHeaders() {
+    final Map<ColumnPath, List<PageHeaderWithOffset>> pageHeaders = new HashMap<ColumnPath, List<PageHeaderWithOffset>>();
+    for (ColumnDescriptor path : schema.getColumns()) {
+      pageHeaders.put(ColumnPath.get(path.getPath()), writers.get(path).getPageHeaderWithOffsets());
+    }
+    return pageHeaders;
   }
 
   public void flushToFileWriter(ParquetFileWriter writer) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageHeaderWithOffset.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageHeaderWithOffset.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.util.Objects;
+
+import org.apache.parquet.format.PageHeader;
+
+/**
+ * PageHeader information along with offset into file.
+ */
+public class PageHeaderWithOffset {
+  final PageHeader pageHeader;
+  final long offset;
+
+  public PageHeaderWithOffset(PageHeader pageHeader, long offset) {
+    this.pageHeader = pageHeader;
+    this.offset = offset;
+  }
+
+  public PageHeaderWithOffset(PageHeader pageHeader, long offset, long headerByteSize) {
+    this.pageHeader = pageHeader;
+    this.offset = offset;
+  }
+
+  public PageHeader getPageHeader() {
+    return pageHeader;
+  }
+
+  public long getOffset() {
+    return offset;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pageHeader, offset);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj != null) {
+      if (obj instanceof PageHeaderWithOffset) {
+        PageHeaderWithOffset that = (PageHeaderWithOffset)obj;
+        return offset == that.offset &&
+          pageHeader.equals(that.pageHeader);
+      }
+    }
+    return false;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageHolder.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageHolder.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+
+/**
+ * Base class for page holders.
+ */
+public abstract class PageHolder {
+  private final int pageIndex;
+  private final int valueCount;
+  private final ColumnDescriptor path;
+  private Encoding valuesEncoding;
+  private BytesInput data;
+  private final Statistics statistics;
+
+  public PageHolder(int pageIndex, ColumnDescriptor path, BytesInput data, int valueCount, Encoding valuesEncoding, Statistics statistics) throws IOException {
+    this.pageIndex = pageIndex;
+    this.path = path;
+    this.statistics = statistics;
+    this.valueCount = valueCount;
+    this.valuesEncoding = valuesEncoding;
+    this.data = BytesInput.copy(data);
+  }
+
+  public void setData(BytesInput data) {
+    // TODO is there way to free old data or wait for GC?
+    this.data = data;
+  }
+
+  public void setValuesEncoding(Encoding valuesEncoding) {
+    this.valuesEncoding = valuesEncoding;
+  }
+
+  public int getPageIndex() {
+    return pageIndex;
+  }
+
+  public BytesInput getData() {
+    return data;
+  }
+
+  public int getValueCount() {
+    return valueCount;
+  }
+
+  public int getNonNullValueCount() {
+    return valueCount - (int)statistics.getNumNulls();
+  }
+
+  public Statistics getStatistics() {
+    return statistics;
+  }
+
+  public Encoding getValuesEncoding() {
+    return valuesEncoding;
+  }
+
+  public ColumnDescriptor getPath() {
+    return path;
+  }
+
+  public abstract int getDataOffset() throws IOException;
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageV1Holder.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageV1Holder.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.Log.DEBUG;
+import static org.apache.parquet.column.ValuesType.DEFINITION_LEVEL;
+import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.ValuesReader;
+
+/**
+ * Page (v1) holder that holds on to page data and encoding etc.
+ */
+public class PageV1Holder extends PageHolder {
+
+  private final Encoding rlEncoding;
+  private final Encoding dlEncoding;
+
+  public PageV1Holder(int pageIndex, ColumnDescriptor path, BytesInput bytes, int valueCount, Statistics statistics,
+                      Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) throws IOException {
+    super(pageIndex, path, bytes, valueCount, valuesEncoding, statistics);
+    this.rlEncoding = rlEncoding;
+    this.dlEncoding = dlEncoding;
+  }
+
+  public Encoding getRlEncoding() {
+    return rlEncoding;
+  }
+
+  public Encoding getDlEncoding() {
+    return dlEncoding;
+  }
+
+  @Override
+  public int getDataOffset() throws IOException {
+    final ValuesReader rlReader = rlEncoding.getValuesReader(getPath(), REPETITION_LEVEL);
+    final ValuesReader dlReader = dlEncoding.getValuesReader(getPath(), DEFINITION_LEVEL);
+    final ByteBuffer bytes = getData().toByteBuffer();
+    rlReader.initFromPage(getValueCount(), bytes, 0);
+    int next = rlReader.getNextOffset();
+    dlReader.initFromPage(getValueCount(), bytes, next);
+    next = dlReader.getNextOffset();
+    return next;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageV2Holder.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PageV2Holder.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+
+/**
+ * Page (v1) holder that holds on to page data and encoding etc.
+ */
+public class PageV2Holder extends PageHolder {
+  private final int rowCount;
+  private final int nullCount;
+  private final BytesInput repetitionLevels;
+  private final BytesInput definitionLevels;
+
+  public PageV2Holder(int pageIndex, ColumnDescriptor path, int rowCount, int nullCount, int valueCount, BytesInput repetitionLevels, BytesInput definitionLevels, Encoding dataEncoding, BytesInput data, Statistics<?> statistics)
+    throws IOException{
+    super(pageIndex, path, data, valueCount, dataEncoding, statistics);
+    this.rowCount = rowCount;
+    this.nullCount = nullCount;
+    this.repetitionLevels = BytesInput.copy(repetitionLevels);
+    this.definitionLevels = BytesInput.copy(definitionLevels);
+  }
+
+  public int getRowCount() {
+    return rowCount;
+  }
+
+  public int getNullCount() {
+    return nullCount;
+  }
+
+
+  public BytesInput getRepetitionLevels() {
+    return repetitionLevels;
+  }
+
+  public BytesInput getDefinitionLevels() {
+    return definitionLevels;
+  }
+
+  @Override
+  public int getDataOffset() throws IOException {
+    return 0;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -26,6 +26,7 @@ import static org.apache.parquet.hadoop.ParquetWriter.MAX_PADDING_SIZE_DEFAULT;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +38,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.apache.parquet.Log;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.Version;
@@ -47,11 +47,12 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel;
-import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.GlobalMetaData;
@@ -303,24 +304,26 @@ public class ParquetFileWriter {
    * writes a dictionary page page
    * @param dictionaryPage the dictionary page
    */
-  public void writeDictionaryPage(DictionaryPage dictionaryPage) throws IOException {
+  public PageHeaderWithOffset writeDictionaryPage(DictionaryPage dictionaryPage) throws IOException {
     state = state.write();
     if (DEBUG) LOG.debug(out.getPos() + ": write dictionary page: " + dictionaryPage.getDictionarySize() + " values");
     currentChunkDictionaryPageOffset = out.getPos();
     int uncompressedSize = dictionaryPage.getUncompressedSize();
     int compressedPageSize = (int)dictionaryPage.getBytes().size(); // TODO: fix casts
-    metadataConverter.writeDictionaryPageHeader(
+    final PageHeader pageHeader = metadataConverter.writeDictionaryPageHeader(
         uncompressedSize,
         compressedPageSize,
         dictionaryPage.getDictionarySize(),
         dictionaryPage.getEncoding(),
         out);
-    long headerSize = out.getPos() - currentChunkDictionaryPageOffset;
+    long currentPos = out.getPos();
+    long headerSize = currentPos - currentChunkDictionaryPageOffset;
     this.uncompressedLength += uncompressedSize + headerSize;
     this.compressedLength += compressedPageSize + headerSize;
     if (DEBUG) LOG.debug(out.getPos() + ": write dictionary page content " + compressedPageSize);
     dictionaryPage.getBytes().writeAllTo(out);
     currentEncodings.add(dictionaryPage.getEncoding());
+    return new PageHeaderWithOffset(pageHeader, currentPos); // dictionary data starts from currentPos
   }
 
 
@@ -334,7 +337,7 @@ public class ParquetFileWriter {
    * @param valuesEncoding encoding of values
    */
   @Deprecated
-  public void writeDataPage(
+  public PageHeader writeDataPage(
       int valueCount, int uncompressedPageSize,
       BytesInput bytes,
       Encoding rlEncoding,
@@ -344,7 +347,7 @@ public class ParquetFileWriter {
     long beforeHeader = out.getPos();
     if (DEBUG) LOG.debug(beforeHeader + ": write data page: " + valueCount + " values");
     int compressedPageSize = (int)bytes.size();
-    metadataConverter.writeDataPageHeader(
+    PageHeader pageHeader = metadataConverter.writeDataPageHeader(
         uncompressedPageSize, compressedPageSize,
         valueCount,
         rlEncoding,
@@ -359,6 +362,7 @@ public class ParquetFileWriter {
     currentEncodings.add(rlEncoding);
     currentEncodings.add(dlEncoding);
     currentEncodings.add(valuesEncoding);
+    return pageHeader;
   }
 
   /**
@@ -370,7 +374,7 @@ public class ParquetFileWriter {
    * @param dlEncoding encoding of the definition level
    * @param valuesEncoding encoding of values
    */
-  public void writeDataPage(
+  public PageHeader writeDataPage(
       int valueCount, int uncompressedPageSize,
       BytesInput bytes,
       Statistics statistics,
@@ -381,7 +385,7 @@ public class ParquetFileWriter {
     long beforeHeader = out.getPos();
     if (DEBUG) LOG.debug(beforeHeader + ": write data page: " + valueCount + " values");
     int compressedPageSize = (int)bytes.size();
-    metadataConverter.writeDataPageHeader(
+    final PageHeader pageHeader = metadataConverter.writeDataPageHeader(
         uncompressedPageSize, compressedPageSize,
         valueCount,
         statistics,
@@ -398,6 +402,7 @@ public class ParquetFileWriter {
     currentEncodings.add(rlEncoding);
     currentEncodings.add(dlEncoding);
     currentEncodings.add(valuesEncoding);
+    return pageHeader;
   }
 
   /**
@@ -451,9 +456,23 @@ public class ParquetFileWriter {
    * @throws IOException
    */
   public void endBlock() throws IOException {
+    endBlock(null);
+  }
+
+  /**
+   * ends a block once all column chunks have been written
+   * adds page header for each column
+   * @throws IOException
+   */
+  public void endBlock(Map<ColumnPath, List<PageHeaderWithOffset>> pageHeaders) throws IOException {
     state = state.endBlock();
     if (DEBUG) LOG.debug(out.getPos() + ": end block");
     currentBlock.setRowCount(currentRecordCount);
+    if (pageHeaders != null && !pageHeaders.isEmpty()) {
+      for (ColumnChunkMetaData columnChunkMetaData : currentBlock.getColumns()) {
+        columnChunkMetaData.setPageHeaders(pageHeaders.get(columnChunkMetaData.getPath()));
+      }
+    }
     blocks.add(currentBlock);
     currentBlock = null;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -18,11 +18,14 @@
  */
 package org.apache.parquet.hadoop.metadata;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.BooleanStatistics;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.PageHeaderWithOffset;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 /**
@@ -193,6 +196,16 @@ abstract public class ColumnChunkMetaData {
   }
 
 
+  /**
+   * Set page headers for this column chunk.
+   */
+  abstract public void setPageHeaders(List<PageHeaderWithOffset> pageHeaders);
+
+  /**
+   * @return page headers for this column
+   */
+  abstract public List<PageHeaderWithOffset> getPageHeaders();
+
   @Override
   public String toString() {
     return "ColumnMetaData{" + properties.toString() + ", " + getFirstDataPageOffset() + "}";
@@ -207,6 +220,7 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
   private final int totalSize;
   private final int totalUncompressedSize;
   private final Statistics statistics;
+  private List<PageHeaderWithOffset> pageHeaders = null;
 
   /**
    * @param path column identifier
@@ -302,7 +316,18 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
   public Statistics getStatistics() {
    return statistics;
   }
+
+  @Override
+  public List<PageHeaderWithOffset> getPageHeaders() {
+    return pageHeaders;
+  }
+
+  @Override
+  public void setPageHeaders(List<PageHeaderWithOffset> pageHeaders) {
+    this.pageHeaders = pageHeaders;
+  }
 }
+
 class LongColumnChunkMetaData extends ColumnChunkMetaData {
 
   private final long firstDataPageOffset;
@@ -311,6 +336,7 @@ class LongColumnChunkMetaData extends ColumnChunkMetaData {
   private final long totalSize;
   private final long totalUncompressedSize;
   private final Statistics statistics;
+  private List<PageHeaderWithOffset> pageHeaders = null;
 
   /**
    * @param path column identifier
@@ -384,6 +410,16 @@ class LongColumnChunkMetaData extends ColumnChunkMetaData {
    */
   public Statistics getStatistics() {
    return statistics;
+  }
+
+  @Override
+  public List<PageHeaderWithOffset> getPageHeaders() {
+    return pageHeaders;
+  }
+
+  @Override
+  public void setPageHeaders(List<PageHeaderWithOffset> pageHeaders) {
+    this.pageHeaders = pageHeaders;
   }
 }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/PageHeaderUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/PageHeaderUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.util;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.PageHeaderWithOffset;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+
+/**
+ * Utility to validate page headers in footer.
+ */
+
+public class PageHeaderUtil {
+
+  public static void validatePageHeaders(Path file, ParquetMetadata parquetMetadata) throws IOException {
+    FSDataInputStream in = file.getFileSystem(new Configuration()).open(file);
+
+    for (BlockMetaData blockMetaData : parquetMetadata.getBlocks()) {
+      for (ColumnChunkMetaData columnChunkMetaData : blockMetaData.getColumns()) {
+        List<PageHeaderWithOffset> pageHeaders = columnChunkMetaData.getPageHeaders();
+        if (pageHeaders == null || pageHeaders.isEmpty()) {
+          continue;
+        }
+        long startingPos = columnChunkMetaData.getStartingPos();
+        long totalSize = columnChunkMetaData.getTotalSize();
+        long size = 0;
+        int pageIndex = 0;
+        // read page header
+        while (size < totalSize) {
+          in.seek(startingPos);
+          PageHeader pageHeader = Util.readPageHeader(in);
+          Preconditions.checkArgument(pageHeader.equals(pageHeaders.get(pageIndex).getPageHeader()),
+            String.format("header from footer [%s] doesn't match with header fro file [%s]",
+              pageHeader.toString(), pageHeaders.get(pageIndex)));
+          Preconditions.checkArgument(pageHeaders.get(pageIndex).getOffset() == in.getPos(),
+            String.format("invalid offset from footer %d, found in file %d",
+              pageHeaders.get(pageIndex).getOffset(), in.getPos()));
+          pageIndex++;
+          size += pageHeader.getCompressed_page_size() + (in.getPos() - startingPos);
+          startingPos = in.getPos() + pageHeader.getCompressed_page_size();
+        }
+        Preconditions.checkArgument(pageIndex == pageHeaders.size(), String.format("found %d headers, expected %d", pageIndex, pageHeaders.size()));
+        Preconditions.checkArgument(size == totalSize, String.format("found %d total size, expected %d", size, totalSize));
+      }
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDictionaryEncoding.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDictionaryEncoding.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.SortedDictionary;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.recordlevel.PhoneBookWriter;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.PageHeaderUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test Dictionary encoding.
+ */
+public class TestDictionaryEncoding {
+  // Dictionary encoding for columns phone number kind
+  // Partial dictionary encoding for lon, lang
+
+  private static String [] kinds = { "landline", "home", "mobile", "cell", "work" };
+
+  public static List<PhoneBookWriter.User> makeUsers() {
+    List<PhoneBookWriter.User> users = new ArrayList<PhoneBookWriter.User>();
+    for (int i = 0; i < 100; i++) {
+      PhoneBookWriter.Location location = new PhoneBookWriter.Location((double)i % 5, (double) i% 6);
+      users.add(new PhoneBookWriter.User(i, "p" + i, Arrays.asList(new PhoneBookWriter.PhoneNumber(i, kinds[i%kinds.length])), location));
+    }
+
+    for (int i = 100; i < 500; i++) {
+      PhoneBookWriter.Location location = new PhoneBookWriter.Location((double)i, (double) i); // no duplicates should enforce partial dictionary pages
+      users.add(new PhoneBookWriter.User(i, "p" + i, Arrays.asList(new PhoneBookWriter.PhoneNumber(i, kinds[i%kinds.length])), location));
+    }
+    return users;
+  }
+
+  private static File phonebookFile;
+  private static List<PhoneBookWriter.User> users;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    users = makeUsers();
+    phonebookFile = PhoneBookWriter.writeToFile(users, 100, 512);
+  }
+
+  @Test
+  public void validateData() throws IOException {
+    List<Group> found =  PhoneBookWriter.readFile(phonebookFile, FilterCompat.NOOP);
+    List<Group> expected = new ArrayList<Group>();
+    for (PhoneBookWriter.User u : users) {
+      expected.add(PhoneBookWriter.groupFromUser(u));
+    }
+    assertEquals(expected.size(), found.size());
+    Iterator<Group> expectedIter = expected.iterator();
+    Iterator<Group> foundIter = found.iterator();
+    while (expectedIter.hasNext()) {
+      assertEquals(expectedIter.next().toString(), foundIter.next().toString());
+    }
+  }
+
+  @Test
+  public void validatePageHeader() throws Exception {
+    Path path = new Path(phonebookFile.toURI());
+    ParquetMetadata footer = ParquetFileReader.readFooter(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
+    PageHeaderUtil.validatePageHeaders(path, footer);
+  }
+
+  @Test
+  public void testPartialDictionaryEncoding() throws IOException {
+    // make sure all pages for lat long do not use dictionary encoding
+    Path path = new Path(phonebookFile.toURI());
+    Configuration conf = new Configuration();
+    ParquetMetadata readFooter = ParquetFileReader.readFooter(conf, path);
+    String [] latPath = { "location", "lat"};
+    String [] lonPath = { "location", "lon"};
+    String [] kindPath = { "phoneNumbers", "phone", "kind"};
+
+    ColumnDescriptor latColumn = PhoneBookWriter.getColumnDescriptor(latPath);
+    ColumnDescriptor lonColumn = PhoneBookWriter.getColumnDescriptor(lonPath);
+    ColumnDescriptor kindColumn = PhoneBookWriter.getColumnDescriptor(kindPath);
+
+    List<ColumnDescriptor> columns = Arrays.asList(latColumn, lonColumn, kindColumn);
+
+    ParquetFileReader parquetFileReader = new ParquetFileReader(
+      conf,
+      readFooter.getFileMetaData(),
+      path,
+      readFooter.getBlocks(),
+      columns);
+
+    long recordCount = 0;
+    while (true) {
+      PageReadStore pages = parquetFileReader.readNextRowGroup();
+      if (pages == null) {
+        break;
+      }
+      recordCount += pages.getRowCount();
+      for (ColumnDescriptor column : columns) {
+        PageReader pageReader = pages.getPageReader(column);
+        if (column == kindColumn) {
+          assertNotNull(pageReader.readDictionaryPage());
+        } else {
+          assertNull(pageReader.readDictionaryPage());
+        }
+      }
+    }
+    parquetFileReader.close();
+    assertEquals(500, recordCount);
+  }
+
+  @Test
+  public void testSortedDictionaries() throws Exception {
+    // make sure dictionary contents are sorted
+    Path path = new Path(phonebookFile.toURI());
+    Configuration conf = new Configuration();
+    ParquetMetadata readFooter = ParquetFileReader.readFooter(conf, path);
+    String [] kindPath = { "phoneNumbers", "phone", "kind"};
+    ColumnDescriptor kindColumn = PhoneBookWriter.getColumnDescriptor(kindPath);
+    final ParquetProperties parquetProperties = new ParquetProperties(4096, PARQUET_2_0, true);
+    List<ColumnDescriptor> columns = Arrays.asList(kindColumn);
+
+    ParquetFileReader parquetFileReader = new ParquetFileReader(
+      conf,
+      readFooter.getFileMetaData(),
+      path,
+      readFooter.getBlocks(),
+      columns);
+
+    long recordCount = 0;
+    while (true) {
+      PageReadStore pages = parquetFileReader.readNextRowGroup();
+      if (pages == null) {
+        break;
+      }
+      recordCount += pages.getRowCount();
+      PageReader pageReader = pages.getPageReader(kindColumn);
+      DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+      assertNotNull(dictionaryPage);
+      SortedDictionary sortedDictionary = new SortedDictionary(dictionaryPage, kindColumn, parquetProperties);
+      assertEquals(kinds.length, dictionaryPage.getDictionarySize());
+      for (int i = 0; i < dictionaryPage.getDictionarySize(); ++i) {
+        assertEquals(i, sortedDictionary.getNewId(i));
+      }
+    }
+    parquetFileReader.close();
+    assertEquals(500, recordCount);
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.util.PageHeaderUtil;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.InvalidSchemaException;
 import org.apache.parquet.schema.Type;
@@ -95,7 +96,7 @@ public class TestParquetWriter {
         ParquetWriter<Group> writer = new ParquetWriter<Group>(
             file,
             new GroupWriteSupport(),
-            UNCOMPRESSED, 1024, 1024, 512, true, false, version, conf);
+            UNCOMPRESSED, 10240*1024, 1024*1024, 128*1024, true, false, version, conf);
         for (int i = 0; i < 1000; i++) {
           writer.write(
               f.newGroup()
@@ -124,6 +125,7 @@ public class TestParquetWriter {
         }
         reader.close();
         ParquetMetadata footer = readFooter(conf, file, NO_FILTER);
+        PageHeaderUtil.validatePageHeaders(file, footer);
         for (BlockMetaData blockMetaData : footer.getBlocks()) {
           for (ColumnChunkMetaData column : blockMetaData.getColumns()) {
             if (column.getPath().toDotString().equals("binary_field")) {


### PR DESCRIPTION
Sort page dictionaries.
Remove partial dictionary encoding.
Add Parquet page headers (along with file offsets to data) to footer in Parquet writer

@julienledem @jacques-n 